### PR TITLE
change using response object to returning redirect.

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -22,9 +22,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async function (
   const user = parseUser(ctx);
 
   if (!user) {
-    ctx.res.statusCode = 307;
-    ctx.res.setHeader("Location", "/api/oauth");
-    ctx.res.end();
+    return { redirect: { destination: "/api/oauth", permanent: false } };
   }
 
   return { props: { user } };


### PR DESCRIPTION
It's better to return a redirect then to use the context response object. code execution doesn't stop at the `ctx.res.end()`